### PR TITLE
Copy TTE header info when converting to PHAII

### DIFF
--- a/src/gdt/missions/fermi/gbm/tte.py
+++ b/src/gdt/missions/fermi/gbm/tte.py
@@ -51,13 +51,29 @@ class GbmTte(PhotonList):
         except:
             return self.headers[0]['DETNAM']
 
-    # mark TODO: copy over relevant header keywords
     def to_phaii(self, bin_method, *args, time_range=None, energy_range=None,
                  channel_range=None, **kwargs):
         if self.trigtime is not None:
             headers = PhaiiTriggerHeaders()
         else:
             headers = PhaiiHeaders()
+        
+        # do not copy the value of these keys
+        exceptions = ['CREATOR', 'DATATYPE', 'EXTNAME', 'FILENAME', 'FILETYPE',
+                      'HDUCLAS1']
+        # copy over the key values for each header
+        for i in range(self.headers.num_headers):
+            for key, val in self.headers[i].items():
+                if key in exceptions:
+                    continue
+                try:
+                    headers[i][key] = val        
+                except:
+                    # header key is present in TTE but not in PHAII
+                    pass
+        headers['PRIMARY']['FILETYPE'] = 'PHAII'
+        headers['PRIMARY']['DATATYPE'] = 'PHAII'
+        
         return super().to_phaii(bin_method, *args, time_range=time_range, 
                                 energy_range=energy_range, 
                                 channel_range=channel_range, 

--- a/tests/missions/fermi/gbm/test_tte.py
+++ b/tests/missions/fermi/gbm/test_tte.py
@@ -86,6 +86,17 @@ class TestGbmTte(unittest.TestCase):
     def test_to_phaii(self):
         phaii = self.tte.to_phaii(bin_by_time, 1.024)
         self.assertEqual(phaii.data.num_times, 319)
+        self.assertEqual(phaii.detector, self.tte.detector)
+        self.assertEqual(phaii.headers[0]['FILETYPE'], 'PHAII')
+        self.assertEqual(phaii.headers[0]['DATE-OBS'], self.tte.headers[0]['DATE-OBS'])
+        self.assertEqual(phaii.headers[0]['DATE-END'], self.tte.headers[0]['DATE-END'])
+        self.assertEqual(phaii.headers[0]['TSTART'], self.tte.headers[0]['TSTART'])
+        self.assertEqual(phaii.headers[0]['TSTOP'], self.tte.headers[0]['TSTOP'])
+        self.assertEqual(phaii.headers[0]['TRIGTIME'], self.tte.headers[0]['TRIGTIME'])
+        self.assertEqual(phaii.headers[0]['OBJECT'], self.tte.headers[0]['OBJECT'])
+        self.assertEqual(phaii.headers[0]['RA_OBJ'], self.tte.headers[0]['RA_OBJ'])
+        self.assertEqual(phaii.headers[0]['DEC_OBJ'], self.tte.headers[0]['DEC_OBJ'])
+        self.assertEqual(phaii.headers[0]['ERR_RAD'], self.tte.headers[0]['ERR_RAD'])
 
     def test_slice_energy(self):
         tte2 = self.tte.slice_energy((50.0, 300.0))


### PR DESCRIPTION
Resolved a TODO and bug by copying relevant header information.  The problem was discovered when the detector name was expected to be copied over and it was not.  The issue was solved by copying all relevant header information, including detector name, to the PHAII header on conversion. Updated unit tests.