### PR TITLE
Bug fix for McIlwain L reported by standard_title()

### DIFF
--- a/src/gdt/missions/fermi/plot.py
+++ b/src/gdt/missions/fermi/plot.py
@@ -344,6 +344,8 @@ class FermiEarthPlot(EarthPlot):
         if self.spacecraft is not None:
             coord = self.spacecraft.coordinates
             title = 'Latitude, East Longitude: ({0}, {1})\n'.format(*coord)
-            mcl = calc_mcilwain_l(float(coord[0][:-1]), float(coord[1][:-1]))
+            lat = float(coord[0][:-1]) * (-1 if "S" in coord[0] else 1)
+            lon = float(coord[1][:-1]) * (-1 if "W" in coord[1] else 1)
+            mcl = calc_mcilwain_l(lat, lon)
             title += 'McIlwain L: {:.2f}'.format(mcl)
             self._m.set_title(title)


### PR DESCRIPTION
This is a quick bug fix to address incorrectly displayed McIlwain L within the standard_plot() function of the FermiEarthPlot class. I add accounting for North/South and East/West when converting lat/lon strings to floating point values passed to the McIlwain calculation. See Issue https://github.com/USRA-STI/gdt-fermi/issues/16 for more details on the source of the issue.